### PR TITLE
Fixes to Nginx config files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN set -x \
 COPY --chmod=770 files/renew-cert.sh files/start-cron.sh /docker-entrypoint.d/
 RUN ln -s /docker-entrypoint.d/renew-cert.sh /etc/periodic/daily/renew-cert.sh
 
+# Disable use of port 80 by default nginx config
+RUN sed -i "s/listen       80;/listen       81;/g" /etc/nginx/conf.d/default.conf
+
 COPY files/ssl-proxy.conf.template /etc/nginx/templates/

--- a/files/ssl-proxy.conf.template
+++ b/files/ssl-proxy.conf.template
@@ -11,6 +11,7 @@ server {
   ssl_ciphers         HIGH:!aNULL:!MD5;
 
   location / {
+    client_max_body_size 0;
     proxy_pass http://localhost:${APP_PORT};
   }
 }


### PR DESCRIPTION
This branch makes two fixes to the config files used by nginx to disable the client max body size check and to modify the default configuration to free up port 80.